### PR TITLE
Add more flexibility on network binding

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,8 +26,8 @@ func init() {
 		"/etc/ipsec.conf",
 		"Path to the ipsec config file.")
 
-	RootCmd.PersistentFlags().IntVar(&exporter.WebListenAddress, flagWebListenAddress,
-		9536,
+	RootCmd.PersistentFlags().StringVar(&exporter.WebListenAddress, flagWebListenAddress,
+		":9536",
 		"Address on which to expose metrics.")
 }
 

--- a/exporter/serve.go
+++ b/exporter/serve.go
@@ -6,7 +6,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/log"
 	"net/http"
-	"strconv"
 )
 
 var IpSecConfigFile string

--- a/exporter/serve.go
+++ b/exporter/serve.go
@@ -40,7 +40,7 @@ func Serve() {
 	http.Handle("/metrics", promhttp.Handler())
 
 	log.Infoln("Listening on", WebListenAddress)
-	err = http.ListenAndServe(":"+strconv.Itoa(WebListenAddress), nil)
+	err = http.ListenAndServe(WebListenAddress, nil)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
It would be useful if we can specify:

- Network interface address with port (IPv4:port or IPv6:port)
- Keep intact generic binding (:port)

This pull request implement this behavior.