### PR TITLE
Running ipsec exporter with unprivileged user

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,7 +31,7 @@ func init() {
 	RootCmd.PersistentFlags().IntVar(&exporter.WebListenAddress, flagWebListenAddress,
 		9536,
 		"Address on which to expose metrics.")
-	RootCmd.PersistentFlags().BoolVar(&exporter.Sudo, flagSudo,
+	RootCmd.PersistentFlags().BoolVar(&ipsec.Sudo, flagSudo,
 		false,
 		"Executing command with sudo.")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"github.com/dennisstritzke/ipsec_exporter/exporter"
+	"github.com/dennisstritzke/ipsec_exporter/ipsec"
 	"github.com/spf13/cobra"
 	"os"
 )
@@ -10,6 +11,7 @@ import (
 const (
 	flagIpsecConfigFile  = "config-path"
 	flagWebListenAddress = "web.listen-address"
+	flagSudo = "enable.sudo"
 )
 
 var Version string
@@ -29,6 +31,9 @@ func init() {
 	RootCmd.PersistentFlags().IntVar(&exporter.WebListenAddress, flagWebListenAddress,
 		9536,
 		"Address on which to expose metrics.")
+	RootCmd.PersistentFlags().BoolVar(&exporter.Sudo, flagSudo,
+		false,
+		"Executing command with sudo.")
 }
 
 func Execute() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,8 +28,8 @@ func init() {
 		"/etc/ipsec.conf",
 		"Path to the ipsec config file.")
 
-	RootCmd.PersistentFlags().IntVar(&exporter.WebListenAddress, flagWebListenAddress,
-		9536,
+	RootCmd.PersistentFlags().StringVar(&exporter.WebListenAddress, flagWebListenAddress,
+		"0.0.0.0:9536",
 		"Address on which to expose metrics.")
 	RootCmd.PersistentFlags().BoolVar(&ipsec.Sudo, flagSudo,
 		false,

--- a/ipsec/status.go
+++ b/ipsec/status.go
@@ -3,7 +3,6 @@ package ipsec
 import (
 	"github.com/prometheus/common/log"
 	"os/exec"
-	"os/user"
 	"regexp"
 	"strconv"
 )

--- a/ipsec/status.go
+++ b/ipsec/status.go
@@ -34,7 +34,21 @@ type cliStatusProvider struct {
 }
 
 func (c *cliStatusProvider) statusOutput(tunnel connection) (string, error) {
-	cmd := exec.Command("ipsec", "statusall", tunnel.name)
+        var args [3]string
+
+        user, _ := user.Current()
+
+        if user.Username != "root" {
+                args[0] = "/bin/sh"
+                args[1] = "-c"
+                args[2] = "sudo ipsec statusall " + tunnel.name
+        } else {
+                args[0] = "ipsec"
+                args[1] = "statusall"
+                args[2] = tunnel.name
+        }
+
+        cmd := exec.Command(args[0], args[1], args[2])
 	out, err := cmd.Output()
 
 	if err != nil {

--- a/ipsec/status.go
+++ b/ipsec/status.go
@@ -3,6 +3,7 @@ package ipsec
 import (
 	"github.com/prometheus/common/log"
 	"os/exec"
+	"os/user"
 	"regexp"
 	"strconv"
 )

--- a/ipsec/status.go
+++ b/ipsec/status.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 )
 
+var Sudo bool
+
 type status struct {
 	up         bool
 	status     connectionStatus
@@ -37,9 +39,7 @@ type cliStatusProvider struct {
 func (c *cliStatusProvider) statusOutput(tunnel connection) (string, error) {
         var args [3]string
 
-        user, _ := user.Current()
-
-        if user.Username != "root" {
+        if Sudo == true {
                 args[0] = "/bin/sh"
                 args[1] = "-c"
                 args[2] = "sudo ipsec statusall " + tunnel.name


### PR DESCRIPTION
Hello,

I would love to be able to run the ipsec prometheus exporter with unprivileged user:

- Detect if the exporter is running with root privileges and if it is keep the old behavior
- If not use sudo to get ipsec metrics

```
username ALL=(ALL) NOPASSWD: /usr/sbin/ipsec statusall *
```

Add this block to allow exporter user to retrieve metrics.