### PR TITLE
Treat tunnel as established if contains REKEYED

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor
+ipsec_exporter

--- a/ipsec/status.go
+++ b/ipsec/status.go
@@ -79,7 +79,7 @@ func queryStatus(ipSecConfiguration *Configuration, provider statusProvider) map
 
 func extractStatus(statusLine []byte) connectionStatus {
 	noMatchRegex := regexp.MustCompile(`no match`)
-	tunnelEstablishedRegex := regexp.MustCompile(`{[0-9]+}: *INSTALLED`)
+	tunnelEstablishedRegex := regexp.MustCompile(`{[0-9]+}: *(INSTALLED|REKEYED)`)
 	connectionEstablishedRegex := regexp.MustCompile(`[[0-9]+]: *ESTABLISHED`)
 
 	if connectionEstablishedRegex.Match(statusLine) {

--- a/ipsec/status.go
+++ b/ipsec/status.go
@@ -79,7 +79,7 @@ func queryStatus(ipSecConfiguration *Configuration, provider statusProvider) map
 
 func extractStatus(statusLine []byte) connectionStatus {
 	noMatchRegex := regexp.MustCompile(`no match`)
-	tunnelEstablishedRegex := regexp.MustCompile(`{[0-9]+}: *(INSTALLED|REKEYED)`)
+	tunnelEstablishedRegex := regexp.MustCompile(`{[0-9]+}: *(INSTALLED|REKEYED|REKEYING)`)
 	connectionEstablishedRegex := regexp.MustCompile(`[[0-9]+]: *ESTABLISHED`)
 
 	if connectionEstablishedRegex.Match(statusLine) {

--- a/ipsec/status_test.go
+++ b/ipsec/status_test.go
@@ -149,8 +149,8 @@ func TestStatus_connectionUpTunnelMissing(t *testing.T) {
 	input := "Security Associations (1 up, 0 connecting):\n  fancy[3]: ESTABLISHED 16 hours ago, 10.0.0.7[213.123.123.9]...212.93.93.93[212.93.93.93]\n	 fancy{134}:  REKEYED, TUNNEL, reqid 2, ESP in UDP SPIs: cc2e965d_i 6d01c0d7_o\n 	fancy{134}:   10.2.0.112/29 === 10.3.0.0/24"
 	status := extractStatus([]byte(input))
 
-	if status != connectionEstablished {
-		t.Errorf("Expected tunnel to be 'connectionEstablished', but was state %d", status)
+	if status != tunnelInstalled {
+		t.Errorf("Expected tunnel to be 'tunnelInstalled', but was state %d", status)
 	}
 }
 


### PR DESCRIPTION
We're getting alerts for a short periods when output
of strongswan shows REKEYED instead of INSTALLED.

Fixes #33 